### PR TITLE
Handle missing ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Simple web application built with Flask and yt-dlp to download videos or audio f
 
 ## Setup
 
+This application requires [ffmpeg](https://ffmpeg.org) to merge video and audio streams.
+Ensure it is installed and available in your PATH before running the app.
+
 ```bash
 pip install -r requirements.txt
 python app.py

--- a/app.py
+++ b/app.py
@@ -39,8 +39,12 @@ def download():
             )
             ydl_opts['merge_output_format'] = 'mp4'
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(url, download=True)
-            filename = ydl.prepare_filename(info)
+            try:
+                info = ydl.extract_info(url, download=True)
+                filename = ydl.prepare_filename(info)
+            except yt_dlp.utils.DownloadError:
+                flash('Failed to download video. Ensure ffmpeg is installed.')
+                return redirect(url_for('index'))
         return send_file(filename, as_attachment=True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- handle download failures when ffmpeg is missing by flashing a message and redirecting
- document ffmpeg requirement in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4fad3cbb083208d866928a7466ed5