### PR TITLE
Add playlist handling and download progress feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ python app.py
 ```
 
 Open your browser at `http://localhost:5000` and enter a YouTube URL. Choose the desired quality (video resolution or audio) and download the file.
+
+### Playlists
+
+Playlist URLs are detected automatically and downloaded in their entirety. The resulting files are packaged into a ZIP archive for download.
+
+### Progress feedback
+
+Downloads run in the background and the web interface polls the server for updates. A progress bar reflects the download status.
+
+### Limitations
+
+- Progress information is kept in memory and is lost if the server restarts.
+- Large playlists may take significant time and disk space while preparing the ZIP archive.
+

--- a/app.py
+++ b/app.py
@@ -1,51 +1,134 @@
 import os
+import shutil
 import tempfile
-from flask import Flask, render_template, request, send_file, redirect, url_for, flash
+import uuid
+from threading import Thread
+
+from flask import (
+    Flask,
+    flash,
+    jsonify,
+    render_template,
+    request,
+    send_file,
+    url_for,
+    redirect,
+)
 import yt_dlp
 
 app = Flask(__name__)
 app.secret_key = "change-me"
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+# Stores progress information for active downloads
+downloads = {}
 
-@app.route('/download', methods=['POST'])
-def download():
-    url = request.form.get('url')
-    quality = request.form.get('quality', 'best')
-    if not url:
-        flash('Please provide a YouTube URL.')
-        return redirect(url_for('index'))
-    # Create a temporary directory to store the download
-    with tempfile.TemporaryDirectory() as tmpdir:
+
+def progress_hook(job_id):
+    """Create a yt_dlp progress hook for a job id."""
+
+    def hook(d):
+        if d.get("status") == "downloading":
+            total = d.get("total_bytes") or d.get("total_bytes_estimate")
+            if total:
+                downloads[job_id]["progress"] = int(
+                    d.get("downloaded_bytes", 0) * 100 / total
+                )
+        elif d.get("status") == "finished":
+            downloads[job_id]["status"] = "processing"
+            downloads[job_id]["filepath"] = d.get("filename")
+
+    return hook
+
+
+def run_download(job_id, url, quality):
+    """Perform the actual download in a background thread."""
+
+    downloads[job_id] = {"progress": 0, "status": "downloading", "filepath": None}
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Detect whether the URL is a playlist
+        with yt_dlp.YoutubeDL({"quiet": True}) as info_ydl:
+            info = info_ydl.extract_info(url, download=False)
+        is_playlist = isinstance(info, dict) and info.get("entries")
+
         ydl_opts = {
-            'format': 'best',
-            'outtmpl': os.path.join(tmpdir, '%(title)s.%(ext)s'),
-            'quiet': True,
+            "format": "best",
+            "outtmpl": os.path.join(tmpdir, "%(title)s.%(ext)s"),
+            "quiet": True,
+            "progress_hooks": [progress_hook(job_id)],
+            "noplaylist": not is_playlist,
         }
-        if quality == 'audio':
-            ydl_opts.update({
-                'format': 'bestaudio/best',
-                'postprocessors': [{
-                    'key': 'FFmpegExtractAudio',
-                    'preferredcodec': 'mp3',
-                    'preferredquality': '192',
-                }]
-            })
-        elif quality in {'1080p', '720p', '480p'}:
-            ydl_opts['format'] = (
+        if quality == "audio":
+            ydl_opts.update(
+                {
+                    "format": "bestaudio/best",
+                    "postprocessors": [
+                        {
+                            "key": "FFmpegExtractAudio",
+                            "preferredcodec": "mp3",
+                            "preferredquality": "192",
+                        }
+                    ],
+                }
+            )
+        elif quality in {"1080p", "720p", "480p"}:
+            ydl_opts["format"] = (
                 f"bestvideo[height<={quality.rstrip('p')}]" + "+bestaudio/best"
             )
-            ydl_opts['merge_output_format'] = 'mp4'
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            try:
-                info = ydl.extract_info(url, download=True)
-                filename = ydl.prepare_filename(info)
-            except yt_dlp.utils.DownloadError:
-                flash('Failed to download video. Ensure ffmpeg is installed.')
-                return redirect(url_for('index'))
-        return send_file(filename, as_attachment=True)
+            ydl_opts["merge_output_format"] = "mp4"
 
-if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+        if is_playlist:
+            ydl_opts["outtmpl"] = os.path.join(
+                tmpdir, "%(playlist)s/%(playlist_index)s - %(title)s.%(ext)s"
+            )
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
+
+        if is_playlist:
+            archive_base = os.path.join(tmpdir, "playlist")
+            zip_path = shutil.make_archive(archive_base, "zip", tmpdir)
+            downloads[job_id]["filepath"] = zip_path
+
+        downloads[job_id]["status"] = "finished"
+    except Exception as exc:  # pragma: no cover - best effort
+        downloads[job_id]["status"] = "error"
+        downloads[job_id]["message"] = str(exc)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/start", methods=["POST"])
+def start_download():
+    url = request.form.get("url")
+    quality = request.form.get("quality", "best")
+    if not url:
+        return jsonify({"error": "No URL provided"}), 400
+    job_id = uuid.uuid4().hex
+    thread = Thread(target=run_download, args=(job_id, url, quality), daemon=True)
+    thread.start()
+    return jsonify({"job_id": job_id})
+
+
+@app.route("/progress/<job_id>")
+def progress(job_id):
+    info = downloads.get(job_id)
+    if not info:
+        return jsonify({"status": "unknown"}), 404
+    return jsonify(info)
+
+
+@app.route("/file/<job_id>")
+def file(job_id):
+    info = downloads.get(job_id)
+    if not info or info.get("status") != "finished":
+        flash("File not ready for download.")
+        return redirect(url_for("index"))
+    return send_file(info["filepath"], as_attachment=True)
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0")

--- a/static/style.css
+++ b/static/style.css
@@ -51,3 +51,22 @@ button:hover {
     color: #ff512f;
     margin-bottom: 1rem;
 }
+
+.progress {
+    width: 100%;
+    background-color: #eee;
+    border-radius: 6px;
+    overflow: hidden;
+    margin-top: 1rem;
+}
+
+.progress-bar {
+    height: 16px;
+    background-color: #ff512f;
+    width: 0%;
+    transition: width 0.3s;
+}
+
+#status {
+    margin-top: 0.5rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
             </ul>
           {% endif %}
         {% endwith %}
-        <form action="{{ url_for('download') }}" method="post" class="download-form">
+        <form id="download-form" action="#" method="post" class="download-form">
             <input type="text" name="url" placeholder="Enter YouTube URL" required>
             <select name="quality">
                 <option value="best" selected>Best Video</option>
@@ -31,6 +31,42 @@
             </select>
             <button type="submit">Download</button>
         </form>
+        <div id="progress-container" class="progress" style="display:none;">
+            <div id="progress-bar" class="progress-bar"></div>
+        </div>
+        <div id="status"></div>
     </div>
+    <script>
+    document.getElementById('download-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const formData = new FormData(this);
+        fetch('{{ url_for('start_download') }}', {method: 'POST', body: formData})
+            .then(res => res.json())
+            .then(data => {
+                if (!data.job_id) {
+                    document.getElementById('status').textContent = data.error || 'Error starting download';
+                    return;
+                }
+                const jobId = data.job_id;
+                document.getElementById('progress-container').style.display = 'block';
+                const interval = setInterval(() => {
+                    fetch('/progress/' + jobId)
+                        .then(r => r.json())
+                        .then(info => {
+                            if (info.progress !== undefined) {
+                                document.getElementById('progress-bar').style.width = info.progress + '%';
+                            }
+                            document.getElementById('status').textContent = info.status || '';
+                            if (info.status === 'finished') {
+                                clearInterval(interval);
+                                window.location = '/file/' + jobId;
+                            } else if (info.status === 'error') {
+                                clearInterval(interval);
+                            }
+                        });
+                }, 1000);
+            });
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect playlist URLs and enable yt-dlp playlist downloads
- stream download progress to the front-end via AJAX polling and progress bar
- document usage, playlist support, and limitations

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4fbc00d2c83208751656cad8fe5dc