### PR TITLE
Add pytest tests for download behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ python app.py
 ```
 
 Open your browser at `http://localhost:5000` and enter a YouTube URL. Choose the desired quality (video resolution or audio) and download the file.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+import pytest
+from flask import Response, get_flashed_messages
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import app as youtube_app
+
+
+def test_successful_download(monkeypatch):
+    class DummyYDL:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+        def extract_info(self, url, download):
+            return {'id': '123', 'title': 'video', 'ext': 'mp4'}
+        def prepare_filename(self, info):
+            return 'dummy.mp4'
+
+    def fake_send_file(filename, as_attachment=True):
+        return Response('filedata', mimetype='text/plain')
+
+    monkeypatch.setattr(youtube_app.yt_dlp, 'YoutubeDL', lambda opts: DummyYDL())
+    monkeypatch.setattr(youtube_app, 'send_file', fake_send_file)
+
+    client = youtube_app.app.test_client()
+    response = client.post('/download', data={'url': 'https://youtu.be/test'})
+
+    assert response.status_code == 200
+    assert response.data == b'filedata'
+
+
+def test_ffmpeg_missing_flash(monkeypatch):
+    class DummyYDL:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+        def extract_info(self, url, download):
+            raise youtube_app.yt_dlp.utils.DownloadError('ffmpeg not found')
+        def prepare_filename(self, info):
+            return 'dummy.mp4'
+
+    monkeypatch.setattr(youtube_app.yt_dlp, 'YoutubeDL', lambda opts: DummyYDL())
+
+    client = youtube_app.app.test_client()
+    with client:
+        response = client.post('/download', data={'url': 'https://youtu.be/test'}, follow_redirects=True)
+        messages = get_flashed_messages()
+
+    assert response.status_code == 200
+    assert 'Failed to download video. Ensure ffmpeg is installed.' in messages


### PR DESCRIPTION
## Summary
- add pytest suite with mocks for yt_dlp to check successful downloads and ffmpeg-missing flashes
- document running tests with pytest in README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4fbbf63a883208f43e734bf5c896b